### PR TITLE
refactor: drop pkg_resources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
 > - Fixed: 🐛
 > - Security: 🛡
 
+## Unreleased
+
+🐛 Replaced deprecated `pkg_resources` usage with `importlib.metadata` to avoid
+  deprecation warnings on Python 3.12+.
+
 ## Version 1.1.3
 
 🐛 Fixed CVD-Update version check in PyPI package repository on startup.

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -36,7 +36,10 @@ from pathlib import Path
 
 import click
 import colorlog
-import importlib.metadata
+try:
+    from importlib.metadata import PackageNotFoundError, version as _get_version
+except ImportError:  # pragma: no cover - backport for older Pythons
+    from importlib_metadata import PackageNotFoundError, version as _get_version
 from http.server import HTTPServer
 from RangeHTTPServer import RangeRequestHandler
 
@@ -55,6 +58,13 @@ module_logger.setLevel(logging.DEBUG)
 
 from colorama import Fore, Back, Style
 
+
+def _package_version() -> str:
+    try:
+        return _get_version('cvdupdate')
+    except PackageNotFoundError:
+        return '0.0'
+
 #
 # CLI Interface
 #
@@ -63,7 +73,7 @@ from colorama import Fore, Back, Style
     + __doc__ + "\n"
     + Fore.GREEN
     + _description + "\n"
-    + f"\nVersion {importlib.metadata.version('cvdupdate')}\n"
+    + f"\nVersion {_package_version()}\n"
     + Style.RESET_ALL
     + _copyright,
 )

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -33,7 +33,10 @@ from enum import Enum
 from pathlib import Path
 from typing import *
 
-import importlib.metadata
+try:
+    from importlib.metadata import PackageNotFoundError, version as _get_version
+except ImportError:  # pragma: no cover - backport for older Pythons
+    from importlib_metadata import PackageNotFoundError, version as _get_version
 try:
     import requests
 except ModuleNotFoundError:
@@ -136,8 +139,8 @@ class CVDUpdate:
             verbose:        Enable DEBUG-level logs and other verbose messages.
         """
         try:
-            self.version = importlib.metadata.version('cvdupdate')
-        except importlib.metadata.PackageNotFoundError:
+            self.version = _get_version('cvdupdate')
+        except PackageNotFoundError:
             self.version = "0.0"
         self.verbose = verbose
         self._read_config(
@@ -929,7 +932,7 @@ class CVDUpdate:
             """Checks if a newer version of the specified module is available on PyPI."""
             self.logger.debug(f'Checking for a newer version of {name}.')
             try:
-                current_version_str = importlib.metadata.version(name)
+                current_version_str = _get_version(name)
                 current_version = version.parse(current_version_str)
 
                 response = requests.get(f"https://pypi.org/pypi/{name}/json")  # Get package info
@@ -950,7 +953,7 @@ class CVDUpdate:
                 self.logger.debug(f"Version check failed: {e}")  # Log the error
                 return True  # Assume up-to-date on error
 
-            except importlib.metadata.PackageNotFoundError:
+            except PackageNotFoundError:
                 self.logger.error(f"Package {name} not found locally.")
                 return True  # Assuming not found means no update possible
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setuptools.setup(
         "requests",
         "dnspython>=2.1.0",
         "rangehttpserver",
-        "setuptools",
         "packaging",
     ],
     classifiers=[


### PR DESCRIPTION
## Summary
- eliminate deprecated pkg_resources usage in favor of importlib.metadata
- remove setuptools runtime dependency
- document removal in changelog

## Testing
- `pytest`